### PR TITLE
Added 'validatevalues' global config option & default options bug fix

### DIFF
--- a/lib/openzwave.js
+++ b/lib/openzwave.js
@@ -36,30 +36,32 @@ var _options = {
 	driverattempts: 3,
 	pollinterval: 500,
 	suppressrefresh: true,
-}
+	validatevalues: true,
+};
 var ZWave = function(path, options) {
 	options = options || {};
-	options.modpath = options.modpath || _options.modpath;
-	options.consoleoutput = options.consoleoutput || _options.consoleoutput;
-	options.logging = options.logging || _options.logging;
-	options.saveconfig = options.saveconfig || _options.saveconfig;
-	options.driverattempts = options.driverattempts || _options.driverattempts;
-	options.pollinterval = options.pollinterval || _options.pollinterval;
-	options.suppressrefresh = options.suppressrefresh || _options.suppressrefresh;
+	options.modpath = options.hasOwnProperty("modpath") ? options.modpath : _options.modpath;
+	options.consoleoutput = options.hasOwnProperty("consoleoutput") ? options.consoleoutput : _options.consoleoutput;
+	options.logging = options.hasOwnProperty("logging") ? options.logging : _options.logging;
+	options.saveconfig = options.hasOwnProperty("saveconfig") ? options.saveconfig : _options.saveconfig;
+	options.driverattempts = options.hasOwnProperty("driverattempts") ? options.driverattempts : _options.driverattempts;
+	options.pollinterval = options.hasOwnProperty("pollinterval") ? options.pollinterval : _options.pollinterval;
+	options.suppressrefresh = options.hasOwnProperty("suppressrefresh") ? options.suppressrefresh : _options.suppressrefresh;
+	options.validatevalues = options.hasOwnProperty('validatevalues') ? options.validatevalues : _options.validatevalues;
 	this.path = path;
 	this.addon = new addon(options);
 	this.addon.emit = this.emit.bind(this);
-}
+};
 
 inherits(ZWave, events.EventEmitter);
 inherits(ZWave, addon);
 
 ZWave.prototype.connect = function() {
 	this.addon.connect(this.path);
-}
+};
 
 ZWave.prototype.disconnect = function() {
 	this.addon.disconnect(this.path);
-}
+};
 
 module.exports = ZWave;

--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -86,6 +86,9 @@ static std::list<NodeInfo *> znodes;
 
 static uint32_t homeid;
 
+// Validate values option flag
+static bool validate_values;
+
 /*
  * Return the node for this request.
  */
@@ -223,7 +226,7 @@ void async_cb_handler(uv_async_t *handle, int status)
 					node->values.push_back(value);
 					pthread_mutex_unlock(&znodes_mutex);
 				}
-				OpenZWave::Manager::Get()->SetChangeVerified(value, true);
+				OpenZWave::Manager::Get()->SetChangeVerified(value, validate_values);
 			}
 
 			/*
@@ -441,6 +444,11 @@ Handle<Value> OZW::New(const Arguments& args)
 	OpenZWave::Options::Get()->AddOptionBool("IntervalBetweenPolls", true);
 	OpenZWave::Options::Get()->AddOptionBool("SuppressValueRefresh", opts->Get(String::New("suppressrefresh"))->BooleanValue());
 	OpenZWave::Options::Get()->Lock();
+
+	//Validation is technically set on a per-value basis, but requires a reference to the ValueID class to set,
+	//so would require a more major change to how Values are currently handled on the JS side. Instead this just
+	//saves to a static/file-scope config var which is picked up in the async callback
+	validate_values = opts->Get(String::New("validatevalues"))->BooleanValue();
 
 	return scope.Close(args.This());
 }


### PR DESCRIPTION
- validatevalues addresses issue #37
- Option parsing was done by using || with passed-in options, going to a
  default value otherwise. However, for a boolean flag with a "true"
  default, this makes it impossible to set the value false. This commit
  fixes this issue using hasOwnProperty.
