### PR TITLE
Added setConfigParam method to wrap OpenZWave Manager::SetConfigParam

### DIFF
--- a/src/openzwave.cc
+++ b/src/openzwave.cc
@@ -37,6 +37,7 @@ struct OZW: ObjectWrap {
 	static Handle<Value> New(const Arguments& args);
 	static Handle<Value> Connect(const Arguments& args);
 	static Handle<Value> Disconnect(const Arguments& args);
+	static Handle<Value> SetConfigParam(const Arguments& args);
 	static Handle<Value> SetValue(const Arguments& args);
 	static Handle<Value> SetLevel(const Arguments& args);
 	static Handle<Value> SetLocation(const Arguments& args);
@@ -480,6 +481,28 @@ Handle<Value> OZW::Disconnect(const Arguments& args)
 }
 
 /*
+ * Set Config Parameters
+ */
+Handle<Value> OZW::SetConfigParam(const Arguments& args)
+{
+	HandleScope scope;
+
+	uint32_t homeid = args[0]->ToNumber()->Value();
+	uint8_t nodeid = args[1]->ToNumber()->Value();
+	uint8_t param = args[2]->ToNumber()->Value();
+	int32_t value = args[3]->ToNumber()->Value();
+
+	if (args.Length() < 5) {
+		OpenZWave::Manager::Get()->SetConfigParam(homeid, nodeid, param, value);
+	} else {
+		uint8_t size = args[4]->ToNumber()->Value();
+		OpenZWave::Manager::Get()->SetConfigParam(homeid, nodeid, param, value, size);
+	}
+
+	return scope.Close(Undefined());
+}
+
+/*
  * Generic value set.
  */
 Handle<Value> OZW::SetValue(const Arguments& args)
@@ -709,6 +732,7 @@ extern "C" void init(Handle<Object> target)
 
 	NODE_SET_PROTOTYPE_METHOD(t, "connect", OZW::Connect);
 	NODE_SET_PROTOTYPE_METHOD(t, "disconnect", OZW::Disconnect);
+	NODE_SET_PROTOTYPE_METHOD(t, "setConfigParam", OZW::SetConfigParam);
 	NODE_SET_PROTOTYPE_METHOD(t, "setValue", OZW::SetValue);
 	NODE_SET_PROTOTYPE_METHOD(t, "setLevel", OZW::SetLevel);
 	NODE_SET_PROTOTYPE_METHOD(t, "setLocation", OZW::SetLocation);


### PR DESCRIPTION
This adds the method `setConfigParam` to match the `Manager::SetConfigParam` method in the openzwave library. technically this isn't needed since you could also use the existing `setValue` method with the `commandClasss = 0x70` with most devices, but I think having the explicit convenience method is useful.
